### PR TITLE
Added feature to optionally configure search params in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Each instrument's config.json should use this format:
 }
 ```
 
+Optional searchParams (i.e query string) config entry:
+
+```json
+{
+  "index": "./index.tsx",
+  "isInteractive": true,
+  "name": "DU3",
+  "dimensions": {
+    "width": 1480,
+    "height": 1100
+  },
+  "searchParams": "Index=2"
+}
+```
+*Note: By default the query string will be "Index=1*
+
 Your rollup should output to a bundles folder within your project using this structure:
 ```
 - bundles

--- a/src/renderer/Pages/Canvas/InstrumentFrameElement.tsx
+++ b/src/renderer/Pages/Canvas/InstrumentFrameElement.tsx
@@ -79,7 +79,7 @@ export const InstrumentFrameElement: FC<InstrumentFrameElementProps> = ({ instru
             rootTag.append(mountTag);
 
             const pfdTag = iframeDocument.createElement(`${project.name}-${instrumentFrame.instrumentName}`);
-            pfdTag.setAttribute('url', 'a?Index=1');
+            pfdTag.setAttribute('url', `a?${loadedInstrument.config.searchParams}`);
 
             const scriptTag = iframeDocument.createElement('script');
             scriptTag.text = loadedInstrument.files[1].contents;

--- a/src/renderer/Pages/Canvas/InstrumentFrameElement.tsx
+++ b/src/renderer/Pages/Canvas/InstrumentFrameElement.tsx
@@ -21,6 +21,7 @@ export interface InstrumentConfig {
     isInteractive: boolean,
     name: string,
     dimensions: InstrumentDimensions,
+    searchParams: string,
 }
 
 export interface InstrumentDimensions {

--- a/src/renderer/Project/fs/Instruments.ts
+++ b/src/renderer/Project/fs/Instruments.ts
@@ -33,6 +33,10 @@ export class ProjectInstrumentsHandler {
             };
         }
 
+        if (!config.searchParams) {
+            config.searchParams = "a?Index=1";
+        }
+
         const instrumentBundlesFolder = path.join(project.paths.bundlesSrc, name);
 
         if (!fs.existsSync(instrumentBundlesFolder)) {

--- a/src/renderer/Project/fs/Instruments.ts
+++ b/src/renderer/Project/fs/Instruments.ts
@@ -34,7 +34,7 @@ export class ProjectInstrumentsHandler {
         }
 
         if (!config.searchParams) {
-            config.searchParams = "a?Index=1";
+            config.searchParams = 'Index=1';
         }
 
         const instrumentBundlesFolder = path.join(project.paths.bundlesSrc, name);


### PR DESCRIPTION
Emulates Search Parameters (i.e query strings) in ace by optionally defining it in `config.json`.

`README` is also updated with instructions on using the `searchParams` entry.