### PR TITLE
Include node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your rollup should output to a bundles folder within your project using this str
     - bundle.css
 ```
 
-Open the repository in an IDE of your choice, run `npm i` to install dependencies, then run `npm start`.
+Download and install NodeJS v16. Open the repository in an IDE of your choice, run `npm i` to install dependencies, then run `npm start`.
 
 After running the program, select `New Project` and choose the locations of all your folders. 
 If your folders are setup for ACE beforehand, you can select `Open Project` and select your root directory.


### PR DESCRIPTION
Some folks trying to run ACE get these strange errors: 
![image](https://user-images.githubusercontent.com/98479040/211357885-fd05651c-1cc9-4b54-a713-8d3095d42aa8.png)

Which are caused due to running node18+, unaware the project requires Node 16 to work. 